### PR TITLE
Remove misleading log errors

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -37,7 +37,7 @@ func StartJob(jobName, network string, job JobFunc, interval time.Duration) {
 	jobWrapper := func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				logger.Error("panic", "reason", r, "stack", debug.Stack())
+				logger.Error("panic", "reason", r, "stack", string(debug.Stack()))
 				err = fmt.Errorf("panic: %v", r)
 			}
 		}()

--- a/main.go
+++ b/main.go
@@ -162,14 +162,13 @@ func main() {
 func commandRun(ctx *cli.Context) error {
 	slog.Info("running recall-exporter", "git-commit", GitCommit, "build-time", BuildTime)
 
-	go tryToStartSubnetJobs(ctx)
-
 	parentChainEP, err := newParentChainEndpoint(ctx)
 	if err != nil {
 		return err
 	}
 
 	startParentChainJobs(parentChainEP, ctx)
+	go tryToStartSubnetJobs(ctx)
 
 	metricsAddress := ctx.String(FLAG_METRICS_ADDRESS)
 	metricsPath := ctx.String(FLAG_METRICS_PATH)
@@ -187,10 +186,10 @@ func tryToStartSubnetJobs(ctx *cli.Context) {
 	endpointNotAvailableRetryCounter := retryCount
 	log := slog.With("task", "connectToSubnetEVM")
 	log.Info("starting")
+	defer log.Info("done")
 	for {
 		subnetEP, err = newSubnetEndpoint(ctx)
 		if err == nil {
-			log.Info("connected to subnet EVM endpoint")
 			break
 		}
 
@@ -203,7 +202,7 @@ func tryToStartSubnetJobs(ctx *cli.Context) {
 		}
 
 		if strings.Contains(err.Error(), "exit code: 54") {
-			log.Info("node is not yet in sync")
+			log.Info("node is not in sync yet")
 		} else {
 			log.Warn("failed to connect to subnet EVM endpoint", "error", err)
 		}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lmittmann/tint"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
 )
@@ -183,10 +185,21 @@ func tryToStartSubnetJobs(ctx *cli.Context) {
 	var subnetEP *SubnetEndpoint
 	var err error
 	const retryCount = 3
+
+	gaugeStatus := promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: PROM_NAMESPACE_RECALL,
+		Help:      "Not 0 if recall-exporter is connected to EVM RPC",
+		Name:      "status_connected_to_subnet_evm",
+	})
+
 	endpointNotAvailableRetryCounter := retryCount
 	log := slog.With("task", "connectToSubnetEVM")
-	log.Info("starting")
+	log.Info("start")
+	gaugeStatus.Set(0)
+
 	defer log.Info("done")
+	defer gaugeStatus.Inc()
+
 	for {
 		subnetEP, err = newSubnetEndpoint(ctx)
 		if err == nil {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -161,17 +162,13 @@ func main() {
 func commandRun(ctx *cli.Context) error {
 	slog.Info("running recall-exporter", "git-commit", GitCommit, "build-time", BuildTime)
 
-	subnetEP, err := newSubnetEndpoint(ctx)
-	if err != nil {
-		return err
-	}
+	go tryToStartSubnetJobs(ctx)
 
 	parentChainEP, err := newParentChainEndpoint(ctx)
 	if err != nil {
 		return err
 	}
 
-	startSubnetJobs(subnetEP, ctx)
 	startParentChainJobs(parentChainEP, ctx)
 
 	metricsAddress := ctx.String(FLAG_METRICS_ADDRESS)
@@ -181,6 +178,41 @@ func commandRun(ctx *cli.Context) error {
 
 	http.Handle(metricsPath, promhttp.Handler())
 	return http.ListenAndServe(metricsAddress, nil)
+}
+
+func tryToStartSubnetJobs(ctx *cli.Context) {
+	var subnetEP *SubnetEndpoint
+	var err error
+	const retryCount = 3
+	endpointNotAvailableRetryCounter := retryCount
+	log := slog.With("task", "connectToSubnetEVM")
+	log.Info("starting")
+	for {
+		subnetEP, err = newSubnetEndpoint(ctx)
+		if err == nil {
+			log.Info("connected to subnet EVM endpoint")
+			break
+		}
+
+		if strings.Contains(err.Error(), "dial tcp") {
+			if endpointNotAvailableRetryCounter == 0 {
+				log.Error("failed to connect to subnet EVM endpoint", "totalRetries", retryCount, "error", err)
+				os.Exit(1)
+			}
+			endpointNotAvailableRetryCounter--
+		}
+
+		if strings.Contains(err.Error(), "exit code: 54") {
+			log.Info("node is not yet in sync")
+		} else {
+			log.Warn("failed to connect to subnet EVM endpoint", "error", err)
+		}
+
+		log.Info("sleeping for 10 seconds")
+		time.Sleep(10 * time.Second)
+	}
+
+	startSubnetJobs(subnetEP, ctx)
 }
 
 func setupLogging() {


### PR DESCRIPTION
This PR makes `recall-exporter` wait for `ethapi` if it's not available yet. 
* If it is not possible to connect to `ethapi` endpoint, it waits for 30 seconds and only then logs error and exists.
* If `ethapi` is available but not in sync yet, `recall-exporter` waits until it's is available.

Close #22 